### PR TITLE
Incoming live update

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,6 @@ Name=Crateful<br>
 ## Pairs Great with SoulSeek
 In SoulSeek settings, set your "Finished Downloads" folder to the same folder that you're sorting in Crateful, so you can sort music as it finishes downloading. (Set the "incomplete" downloads somewhere else, so you don't accidentally sort a half downloaded track!)
 
+If the number of "tracks to sort" gets lower than 5, Crateful will reload the "to sort" folder, so you can continuously download & sort tracks without reloading Crateful.
+
 Cheers to full crates!

--- a/README.md
+++ b/README.md
@@ -41,4 +41,6 @@ In SoulSeek settings, set your "Finished Downloads" folder to the same folder th
 
 If the number of "tracks to sort" gets lower than 5, Crateful will reload the "to sort" folder, so you can continuously download & sort tracks without reloading Crateful.
 
+Crateful will get all tracks in the folder selected for sorting, even tracks in nested folders, however it does not delete empty folders on exiting.
+
 Cheers to full crates!

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -212,6 +212,11 @@ impl App {
         self.index += 1;
         self.list_write();
         self.music_player.lock().unwrap().clear();
+        if self.display_list.len() < 5 {
+            self.load_tracks();
+            self.list_write();
+            self.index = 0;
+        }
         self.start_playback();
     }
 
@@ -224,6 +229,11 @@ impl App {
         let _ = fs::remove_file(self.track_list.get(self.index).unwrap());
         self.index += 1;
         self.list_write();
+        if self.display_list.len() < 5 {
+            self.load_tracks();
+            self.list_write();
+            self.index = 0;
+        }
         self.start_playback();
     }
     pub fn pause(&mut self) {


### PR DESCRIPTION
Crateful now updates the "tracks to sort" folder when the number of tracks to sort falls below five.