### PR TITLE
Env

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -125,4 +125,14 @@ impl Envs {
             }
         }
     }
+
+    pub fn destroy_config() {
+        fs::remove_dir_all(
+            dirs::config_dir()
+                .and_then(|a| Some(a.join("crateful/")))
+                .unwrap()
+                .as_path(),
+        )
+        .unwrap();
+    }
 }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -201,6 +201,11 @@ impl App {
         }
         if newpath.as_os_str().is_empty() {
             self.pause();
+            match which {
+                SavePath::A => self.pause_menu.select(Some(1)),
+                SavePath::D => self.pause_menu.select(Some(2)),
+                SavePath::G => self.pause_menu.select(Some(3)),
+            }
             self.pause_mode = PauseMode::SaveSelect(which);
             return ();
         }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -100,6 +100,10 @@ impl App {
 
     /// Set running to false to quit the application.
     pub fn quit(&mut self) {
+        // check the env, delete the file if the user somehow didn't assign a "to sort" folder
+        if !self.incoming.exists() {
+            Envs::destroy_config();
+        }
         self.running = false;
     }
 


### PR DESCRIPTION
Change the menu selected on selecting save paths for first time, to indicate which pause mode user is in.

Destroy the env config in case user somehow exits app without assigning incoming_path variable